### PR TITLE
D3rp3tt3/add flyctl readme

### DIFF
--- a/fly.io/README.md
+++ b/fly.io/README.md
@@ -1,0 +1,9 @@
+# NextJS Build
+A Dagger module to deploy an app to Fly.io with the flyctl CLI.
+
+# Examples
+TODO - Include GraphQL query examples
+
+# Maintainers
+* JF Farge (slumbering)
+* Jenn Allen (d3rp3tt3)

--- a/nextjs-build/README.md
+++ b/nextjs-build/README.md
@@ -1,0 +1,11 @@
+# NextJS Build
+A Dagger module to build NextJS apps. The build is created as a container and exported to a directory.
+
+After building your app, you can use another Dagger module to deploy it, such as by using the *Flyctl* (Fly.io) module.
+
+# Examples
+TODO - Include GraphQL query for `out`
+
+# Maintainers
+* JF Farge (slumbering)
+* Jenn Allen (d3rp3tt3)

--- a/nextjs-build/main.go
+++ b/nextjs-build/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-type NextjsBuild struct {}
+type NextjsBuild struct{}
 
 const (
 	// https://hub.docker.com/_/node
@@ -15,6 +15,7 @@ const (
 	alpineVersion = "3.18"
 )
 
+// Use a directory to build a NextJS app.
 func (d *Directory) BuildNextJS(ctx context.Context) (*Directory, error) {
 	node := dag.Container(ContainerOpts{Platform: Platform("linux/amd64")}).
 		From(fmt.Sprintf("node:%s", nodeJSVersion))
@@ -33,5 +34,6 @@ func (d *Directory) BuildNextJS(ctx context.Context) (*Directory, error) {
 		return nil, err
 	}
 
+	// Export the build directory to be used with other modules, such as deploying with `flyctl deploy`.
 	return build.Directory("out/"), nil
 }


### PR DESCRIPTION
This readme adds documentation and examples for the flyctl module (fly.io) deploy. This readme is used in Daggerverse.